### PR TITLE
Small fix for URIs that are not / terminated

### DIFF
--- a/roles/mailserver/files/nginx/www-files.conf
+++ b/roles/mailserver/files/nginx/www-files.conf
@@ -31,6 +31,14 @@ server {
     include /etc/nginx/conf/proxy_params;
   }
 
+  location ~ ^[^.]*[^/]$ {
+    try_files $uri @rewrite;
+  }
+
+  location @rewrite {
+    return 302 $scheme://$http_host$uri/;
+  }
+
   location ~ ^/~(.+?)(/.*)?$ {
     alias /www/people/$1$2;
     index index.html index.htm;


### PR DESCRIPTION
In the case the user asks for a URI that omits a trailing /
character, AND the URI does NOT include any "." character,
a redirect is sent properly to avoid exposing the backend
container nginx port.